### PR TITLE
fix: Make GraphQL errors also should Hawk error attributes

### DIFF
--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -8,8 +8,8 @@ import { ApolloContext, logger } from '../util';
  * Assert that this endpoint is protected by Hawk.
  */
 function assertHawkAuthenticated(context: ApolloContext): void {
-  if (context.isHawkAuthenticated !== true) {
-    throw new Error(context.isHawkAuthenticated);
+  if (context instanceof Error) {
+    throw context;
   }
 }
 

--- a/src/util/hawk.spec.ts
+++ b/src/util/hawk.spec.ts
@@ -1,19 +1,28 @@
 import Hawk from '@hapi/hawk';
+import { AuthenticationError } from 'apollo-server-micro';
 import { Request } from 'express';
 
 import { hawk } from './hawk';
 
-function createReq(id: string, key: string): Request {
+function createReq({
+  crendentialsId,
+  credentialsKey,
+  timestamp = Math.round(new Date().getTime() / 1000)
+}: {
+  crendentialsId: string;
+  credentialsKey: string;
+  timestamp?: number;
+}): Request {
   const { header } = Hawk.client.header(
     'http://example.com/resource/4?filter=a',
     'GET',
     {
-      timestamp: Math.round(new Date().getTime() / 1000),
+      timestamp,
       nonce: 'Ygvqdz',
       credentials: {
         algorithm: 'sha256',
-        id,
-        key
+        id: crendentialsId,
+        key: credentialsKey
       }
     }
   );
@@ -32,35 +41,67 @@ function createReq(id: string, key: string): Request {
 
 describe('hawk', () => {
   it('should throw an error on invalid id', async done => {
-    const req = createReq('foo', 'bar');
+    const req = createReq({ crendentialsId: 'foo', credentialsKey: 'bar' });
 
-    const result = await hawk(req);
-
-    expect(result).toBe('Hawk: Invalid Hawk id: foo');
+    try {
+      await hawk(req);
+    } catch (error) {
+      expect(error).toEqual(
+        new AuthenticationError('Hawk: Invalid Hawk id: foo')
+      );
+    }
 
     done();
   });
 
   it('should return "Unauthorized" on a plain request', async done => {
-    const req = createReq('foo', 'bar');
+    const req = createReq({ crendentialsId: 'foo', credentialsKey: 'bar' });
     delete req.headers.authorization;
 
-    const result = await hawk(req);
+    try {
+      await hawk(req);
+    } catch (error) {
+      expect(error).toEqual(new AuthenticationError('Hawk: Unauthorized'));
+    }
 
-    expect(result).toBe('Hawk: Unauthorized');
+    done();
+  });
+
+  it('should return "Stale timestamp" along with offset', async done => {
+    const req = createReq({
+      crendentialsId: 'shootismoke-development',
+      credentialsKey: process.env.HAWK_KEY_1_5_0 as string,
+      timestamp: Math.round(new Date().getTime() / 1000) - 5000 // Add a 5s offset
+    });
+
+    try {
+      await hawk(req);
+    } catch (error) {
+      expect(error).toEqual(new AuthenticationError('Hawk: Stale timestamp'));
+
+      expect(error.extensions).toMatchObject({
+        ts: expect.any(Number),
+        tsm: expect.any(String),
+        error: 'Stale timestamp',
+        code: 'UNAUTHENTICATED'
+      });
+    }
 
     done();
   });
 
   it('should work', async done => {
-    const req = createReq(
-      'shootismoke-development',
-      process.env.HAWK_KEY_1_5_0 as string
-    );
+    const req = createReq({
+      crendentialsId: 'shootismoke-development',
+      credentialsKey: process.env.HAWK_KEY_1_5_0 as string
+    });
 
     const result = await hawk(req);
 
-    expect(result).toBe(true);
+    expect(result.credentials).toMatchObject({
+      algorithm: 'sha256',
+      key: process.env.HAWK_KEY_1_5_0
+    });
 
     done();
   });

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,6 +1,8 @@
+import { HawkResult } from './hawk';
+
 /**
  * Shared context for Apollo Server.
  */
 export interface ApolloContext {
-  isHawkAuthenticated: true | string;
+  hawk: HawkResult | Error;
 }


### PR DESCRIPTION
E.g. in case of stale timestamp, the graphql error should show the timestamp offset